### PR TITLE
Allow system's variables to be used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+<a name="1.1.2"></a>
+## [1.1.2](https://github.com/nuxt-community/dotenv-module/compare/v1.1.1...v1.1.2) (2018-07-12)
+
+
 
 <a name="1.1.1"></a>
 ## [1.1.1](https://github.com/nuxt-community/dotenv-module/compare/v1.1.0...v1.1.1) (2018-03-25)

--- a/README.md
+++ b/README.md
@@ -63,6 +63,18 @@ By default, the we'll be loading the `.env` file from the root of your project. 
 }
 ```
 
+### systemvars
+
+By default this is false and variables from your system will be ignored. Setting this to true will allow your system set variables to work.
+
+```js
+{
+  modules: [
+    ['@nuxtjs/dotenv', { systemvars: true }],
+  ]
+}
+```
+
 Note that this is the path to the **folder** where the `.env` file live, not to the `.env` file itself.
 
 The path can be absolute or relative.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxtjs/dotenv",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxtjs/dotenv",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A nuxt.js module that loads your .env file into your context options",
   "license": "MIT",
   "contributors": [

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ export default function DotEnvModule (moduleOptions) {
     return options.only.length === 0 || options.only.includes(key)
   }
 
-  if (systemvars) {
+  if (options.systemvars) {
     Object.keys(process.env).map(key => {
       if(!key in envConfig) {
         envConfig[key] = process.env[key]

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,8 @@ import { parse } from 'dotenv'
 export default function DotEnvModule (moduleOptions) {
   const defaultOptions = {
     only: [],
-    path: this.options.srcDir
+    path: this.options.srcDir,
+    systemvars: false
   }
 
   const options = Object.assign({}, defaultOptions, moduleOptions)
@@ -17,10 +18,19 @@ export default function DotEnvModule (moduleOptions) {
     // file not found, just return
     return
   }
+
   const envConfig = parse(readFileSync(envFilePath))
 
   const isAllowed = key => {
     return options.only.length === 0 || options.only.includes(key)
+  }
+
+  if (systemvars) {
+    Object.keys(process.env).map(key => {
+      if(!key in envConfig) {
+        envConfig[key] = process.env[key]
+      }
+    })
   }
 
   Object.keys(envConfig).forEach((key) => {


### PR DESCRIPTION
I've found using this module will remove already set system variables which is a problem for static sites deployed to hosts like Netlify where a dotenv file is impossible.

This is my attempt to fix it. It's not enabled by default and must be activated via the config option.
```js
{
  modules: [
    ['@nuxtjs/dotenv', { systemvars: true }],
  ]
}
```