### PR TITLE
Move explanation of path to proper location

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ By default, the we'll be loading the `.env` file from the root of your project. 
 }
 ```
 
+Note that this is the path to the **folder** where the `.env` file live, not to the `.env` file itself.
+
+The path can be absolute or relative.
+
 ### systemvars
 
 By default this is false and variables from your system will be ignored. Setting this to true will allow your system set variables to work.
@@ -74,10 +78,6 @@ By default this is false and variables from your system will be ignored. Setting
   ]
 }
 ```
-
-Note that this is the path to the **folder** where the `.env` file live, not to the `.env` file itself.
-
-The path can be absolute or relative.
 
 ### filename
 


### PR DESCRIPTION
The paragraph explaining that `path` is not the location of the file got moved to the `systemvars` section. This moves that explanation back to the correct place.