### PR TITLE
Fix default options path

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import { parse } from 'dotenv'
 export default function DotEnvModule (moduleOptions) {
   const defaultOptions = {
     only: [],
-    path: this.options.srcDir,
+    path: this.options.rootDir,
     filename: '.env',
     systemvars: false
   }


### PR DESCRIPTION
Hello,
I have change the default path because its pointed to srcDir and not rootDir.
Now the file `.env` can be place in root and have `srcDir` to `src` without pass `path` option.

Thanks.